### PR TITLE
fix: Correct name of tap in homebrew installation command

### DIFF
--- a/_pages/docs/next-ls/installation.md
+++ b/_pages/docs/next-ls/installation.md
@@ -21,7 +21,7 @@ If you like to download and manage tools yourself, there are several different w
 Next LS can be easily installed using our first party Homebrew Tap.
 
 ```sh
-brew install elixir-tools/tap/nextls
+brew install elixir-tools/tap/next-ls
 ```
 
 ## Nix


### PR DESCRIPTION
The installation command as documented has a typo in the tap name. Homebrew suggests the correct one, however it should be correct in the documentation.