### PR TITLE
docs: helix configuration for next-ls development

### DIFF
--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -181,10 +181,9 @@ language-servers = ["nextls"]
 command = "path/to/next-ls"
 args = ["--stdio=true"]
 ```
-### Development
+### TCP
 
-If you are running next-ls from the source code, you'll need to communicate with the server over TCP. [It is recommended to use netcat as a proxy.](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
-Assuming the next-ls server runs on port 9000, the LSP configuration should look as follows:
+Helix supports connecting via TCP using `netcat`. https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers
 
 ```toml
 [[language]]
@@ -200,9 +199,9 @@ command = "nc"
 args = ["127.0.0.1", "9000"]
 ```
 
-### Enabling completions
+### Initialization Options
 
-Completions need to be enabled explicitely in the Language Server configuration by passing intialization options under the `config` key.
+Initialization options are configured with the `config` key.
 
 ```toml
 [language-server.nextls]

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -183,29 +183,32 @@ args = ["--stdio=true"]
 ```
 ### Development
 
-If you are running next-ls from the source code, you'll need to have [netcat](https://netcat.sourceforge.net/) installed in order for helix to communicate with the server over TCP.  
+If you are running next-ls from the source code, you'll need to communicate with the server over TCP. [It is recommended to use netcat as a proxy.](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
 Assuming the next-ls server runs on port 9000, the LSP configuration should look as follows:
 
-```diff
+```toml
 [[language]]
 name = "elixir"
 scope = "source.elixir"
-- language-server = { command = "path/to/next-ls", args = ["--stdio=true"] }
-+ language-server = { command = "nc", args = ["127.0.0.1", "9000"] }
+language-server = { command = "nc", args = ["127.0.0.1", "9000"] }
 ```
 If you are using the latest git version of helix use this:
 
-```diff
-[[language]]
-name = "elixir"
-scope = "source.elixir"
-language-servers = ["nextls"]
-
+```toml
 [language-server.nextls]
-- command = "path/to/next-ls"
-- args = ["--stdio=true"]
-+ command = "nc"
-+ args = ["127.0.0.1", "9000"]
+command = "nc"
+args = ["127.0.0.1", "9000"]
+```
+
+### Enabling completions
+
+Completions need to be enabled explicitely in the Language Server configuration by passing intialization options under the `config` key.
+
+```toml
+[language-server.nextls]
+command = "path/to/next-ls"
+args = ["--stdio=true"]
+config = { experimental = { completions = { enable = true } } }
 ```
 
 ## Zed

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -181,6 +181,32 @@ language-servers = ["nextls"]
 command = "path/to/next-ls"
 args = ["--stdio=true"]
 ```
+### Development
+
+If you are running next-ls from the source code, you'll need to have [netcat](https://netcat.sourceforge.net/) installed in order for helix to communicate with the server over TCP.  
+Assuming the next-ls server runs on port 9000, the LSP configuration should look as follows:
+
+```diff
+[[language]]
+name = "elixir"
+scope = "source.elixir"
+- language-server = { command = "path/to/next-ls", args = ["--stdio=true"] }
++ language-server = { command = "nc", args = ["127.0.0.1", "9000"] }
+```
+If you are using the latest git version of helix use this:
+
+```diff
+[[language]]
+name = "elixir"
+scope = "source.elixir"
+language-servers = ["nextls"]
+
+[language-server.nextls]
+- command = "path/to/next-ls"
+- args = ["--stdio=true"]
++ command = "nc"
++ args = ["127.0.0.1", "9000"]
+```
 
 ## Zed
 


### PR DESCRIPTION
As discussed on discord, here's the documentation about how to have helix interact with next-ls for development purposes (over TCP). 