### PR TITLE
docs: using nextls with lsp-mode (for vanilla emacs)

### DIFF
--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -101,6 +101,32 @@ Initialization options can be configured:
      ("nextls" "--stdio=true" :initializationOptions (:experimental (:completions (:enable t)))))))
 ```
 
+### Emacs with lsp-mode
+
+[lsp-mode](https://github.com/emacs-lsp/lsp-mode)
+
+1. Install `nextls` somewhere on your `PATH`
+2. Configure `lsp-mode`
+
+```
+(use-package lsp-mode
+  :ensure t
+  :hook (elixir-ts-mode . lsp)
+  :commands lsp)
+```
+
+3. Add `nextls` to the `lsp-mode` configuration
+
+```
+		(with-eval-after-load 'lsp-mode
+		  (lsp-register-client
+		   (make-lsp-client :new-connection (lsp-stdio-connection '("nextls" "--stdio" ))
+							:multi-root t
+							;; :initialization-options '(:experimental (:completions (:enable t))) ;; Enable the experimental completion mode
+							:activation-fn (lsp-activate-on "elixir")
+							:server-id 'next-ls)))
+```
+
 ### Doom Emacs with lsp-mode
 
 [Doom Emacs](https://github.com/doomemacs/doomemacs)

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -108,7 +108,7 @@ Initialization options can be configured:
 1. Install `nextls` somewhere on your `PATH`
 2. Configure `lsp-mode`
 
-```
+```elisp
 (use-package lsp-mode
   :ensure t
   :hook (elixir-ts-mode . lsp)
@@ -117,15 +117,14 @@ Initialization options can be configured:
 
 3. Add `nextls` to the `lsp-mode` configuration
 
-```
-		(with-eval-after-load 'lsp-mode
-		  (lsp-register-client
-		   (make-lsp-client :new-connection (lsp-stdio-connection '("nextls" "--stdio" ))
-							:multi-root t
-							;; :initialization-options '(:experimental (:completions (:enable t))) ;; Enable the experimental completion mode
-							:activation-fn (lsp-activate-on "elixir")
-							:server-id 'next-ls)))
-```
+```elisp
+(with-eval-after-load 'lsp-mode
+  (lsp-register-client
+   (make-lsp-client :new-connection (lsp-stdio-connection '("nextls" "--stdio" ))
+          :multi-root t
+          ;; :initialization-options '(:experimental (:completions (:enable t))) ;; Enable the experimental completion mode
+          :activation-fn (lsp-activate-on "elixir")
+          :server-id 'next-ls)))
 
 ### Doom Emacs with lsp-mode
 


### PR DESCRIPTION
Adding a new language sever with init options to lsp-mode wasn't so straight forward, so I thought I'd add this for future people.