### PR TITLE
Expand on zed editor setup

### DIFF
--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -263,3 +263,18 @@ Zed will install and manage Next LS for you.
   }
 }
 ```
+
+If for some reason you want to run a local version of `next-ls` you can do the following:
+
+```json
+"elixir": {
+  "lsp": {
+    "local": {
+      "path": "<PATH TO BINARY>",
+      "arguments": ["--stdio"]
+    }
+  }
+},
+```
+
+Where `PATH TO BINARY` is a location to a local build, eg. `/Users/user/next-ls/burrito_out/next_ls_darwin_arm64`.

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -264,7 +264,7 @@ Zed will install and manage Next LS for you.
 }
 ```
 
-If for some reason you want to run a local version of `next-ls` you can do the following:
+If you want to run a local version of `next-ls` you can do the following:
 
 ```json
 "elixir": {


### PR DESCRIPTION
It proved useful for me to run the compiled version of `next-ls` from a specific path. It's a bit easier maintaining a versions this way.

In all reality it would be better to switch `next-ls` to a zed extension since that's now a possibility.