### PR TITLE
feat: adds basic instructions for nvim-lspconfig;

### DIFF
--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -14,11 +14,17 @@ github_stars: elixir-tools/next-ls
 
 ## Neovim
 
-[elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
+- [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
+- You might also decide to install and manage `next-ls` yourself using `nvim-lspconfig`, and perhaps, [`homebrew`](/docs/next-ls/installation/#homebrew) for the `nextls` binary.
+  - ```lua
+    require("lspconfig")["nextls"].setup({
+      cmd = {"nextls", "--stdio"} -- assumes you have `nextls` in your `$PATH`
+    })
+    ```
 
 ### Note
 
-If you are using a Neovim distribution like [LunarVim](https://www.lunarvim.org/), [AstroVim](https://astronvim.com/), or [NVChad](https://nvchad.com/), please make sure to disable any Elixir LSP support that comes out of the box, as it will interfere with `elixir-tools.nvim`. 
+If you are using a Neovim distribution like [LunarVim](https://www.lunarvim.org/), [AstroVim](https://astronvim.com/), or [NVChad](https://nvchad.com/), please make sure to disable any Elixir LSP support that comes out of the box, as it will interfere with `elixir-tools.nvim`.
 
 ## Vim
 
@@ -207,6 +213,7 @@ language-servers = ["nextls"]
 command = "path/to/next-ls"
 args = ["--stdio=true"]
 ```
+
 ### TCP
 
 Helix supports connecting via TCP using `netcat`. https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers
@@ -217,6 +224,7 @@ name = "elixir"
 scope = "source.elixir"
 language-server = { command = "nc", args = ["127.0.0.1", "9000"] }
 ```
+
 If you are using the latest git version of helix use this:
 
 ```toml
@@ -291,10 +299,7 @@ Sublime Text support uses the [LSP for Sublime Text](https://lsp.sublimetext.io/
 {
   "clients": {
     "elixir": {
-      "command": [
-        "nextls",
-        "--stdio"
-      ],
+      "command": ["nextls", "--stdio"],
       "selector": "source.elixir | source.ex | source.exs",
       "initializationOptions": {
         "extensions": {

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -14,11 +14,11 @@ github_stars: elixir-tools/next-ls
 
 ## Neovim
 
-### [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim)
+### elixir-tools.nvim
 
 [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
 
-### [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls)
+### nvim-lspconfig
 
 You might also decide to install and manage `next-ls` yourself using [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls), and perhaps, [`homebrew`](/docs/next-ls/installation/#homebrew) for the `nextls` binary.
 

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -24,11 +24,11 @@ You might also decide to install and manage `next-ls` yourself using [`nvim-lspc
 
 ```lua
  require("lspconfig")["nextls"].setup({
-   cmd = {"nextls", "--stdio"} -- assumes you have the executable `nextls` in your `$PATH`
+   cmd = {"nextls", "--stdio"},
    init_options = {
      experimental = {
        completions = {
-         enable = true, -- this will enable completions support through next-ls
+         enable = true,
        },
      },
    }

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -16,28 +16,29 @@ github_stars: elixir-tools/next-ls
 
 ### elixir-tools.nvim
 
-[elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
+[elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you.
+
+#### Note
+
+If you are using a Neovim distribution like [LunarVim](https://www.lunarvim.org/), [AstroVim](https://astronvim.com/), or [NVChad](https://nvchad.com/), please make sure to disable any Elixir LSP support that comes out of the box, as it will interfere with `elixir-tools.nvim`.
 
 ### nvim-lspconfig
 
-You might also decide to install and manage `next-ls` yourself using [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls), and perhaps, [`homebrew`](/docs/next-ls/installation/#homebrew) for the `nextls` binary.
+Next LS support is built into [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls), you just need to [install Next LS](/docs/next-ls/installation) and set your `cmd`.
 
 ```lua
- require("lspconfig")["nextls"].setup({
-   cmd = {"nextls", "--stdio"},
-   init_options = {
-     experimental = {
-       completions = {
-         enable = true,
-       },
-     },
-   }
- })
+require("lspconfig")["nextls"].setup({
+  cmd = {"nextls", "--stdio"},
+  init_options = {
+    extensions = {
+      credo = { enable = true }
+    },
+    experimental = {
+      completions = { enable = true }
+    }
+  }
+})
 ```
-
-### Note
-
-If you are using a Neovim distribution like [LunarVim](https://www.lunarvim.org/), [AstroVim](https://astronvim.com/), or [NVChad](https://nvchad.com/), please make sure to disable any Elixir LSP support that comes out of the box, as it will interfere with `elixir-tools.nvim`.
 
 ## Vim
 

--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -14,13 +14,26 @@ github_stars: elixir-tools/next-ls
 
 ## Neovim
 
-- [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
-- You might also decide to install and manage `next-ls` yourself using `nvim-lspconfig`, and perhaps, [`homebrew`](/docs/next-ls/installation/#homebrew) for the `nextls` binary.
-  - ```lua
-    require("lspconfig")["nextls"].setup({
-      cmd = {"nextls", "--stdio"} -- assumes you have `nextls` in your `$PATH`
-    })
-    ```
+### [elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim)
+
+[elixir-tools.nvim](https://github.com/elixir-tools/elixir-tools.nvim) is a first party elixir-tools editor plugin and will install and manage Next LS for you
+
+### [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls)
+
+You might also decide to install and manage `next-ls` yourself using [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nextls), and perhaps, [`homebrew`](/docs/next-ls/installation/#homebrew) for the `nextls` binary.
+
+```lua
+ require("lspconfig")["nextls"].setup({
+   cmd = {"nextls", "--stdio"} -- assumes you have the executable `nextls` in your `$PATH`
+   init_options = {
+     experimental = {
+       completions = {
+         enable = true, -- this will enable completions support through next-ls
+       },
+     },
+   }
+ })
+```
 
 ### Note
 

--- a/_pages/docs/next-ls/installation.md
+++ b/_pages/docs/next-ls/installation.md
@@ -53,7 +53,7 @@ Releases are named for the OS and CPU for which they run on, so make sure you do
 If you use the [gh](https://cli.github.com/) CLI, you can easily download release artifacts like so:
 
 ```sh
-gh release download v0.14.2 \
+gh release download v0.22.6 \
   --pattern next_ls_linux_amd64 \
   --output ~/.bin/nextls \
   --clobber \


### PR DESCRIPTION
- now that nvim-lspconfig has a basic config for `next-ls`; it's easier than ever to maintain your own next-ls install in neovim. should you choose to not using `elixir-tools.nvim` for a more full-featured config/setup.