### PR TITLE
Align Zed docs with the current version of the editor

### DIFF
--- a/_pages/docs/next-ls/editors.md
+++ b/_pages/docs/next-ls/editors.md
@@ -260,17 +260,25 @@ config = { experimental = { completions = { enable = true } } }
 
 ## Zed
 
-Zed will install and manage Next LS for you.
+Zed will install and manage Next LS for you. You can make `next-ls` the default with the following config:
 
 ```json
 {
-  // how you enable Next LS, notice the kebab casing
   "languages": {
     "Elixir": {
-      "language_servers": ["next-ls"]
+      "language_servers": ["!lexical", "!elixir-ls", "next-ls"]
+    },
+    "HEEX": {
+      "language_servers": ["!lexical", "!elixir-ls", "next-ls"]
     }
-  },
+  }
+}
+```
 
+Once it's on you can configure it by adding some options:
+
+```json
+{
   "lsp": {
     // how you configure Next LS, notice the kebab casing
     "next-ls": {
@@ -289,20 +297,7 @@ Zed will install and manage Next LS for you.
 }
 ```
 
-If you want to run a local version of `next-ls` you can do the following:
-
-```json
-"elixir": {
-  "lsp": {
-    "local": {
-      "path": "<PATH TO BINARY>",
-      "arguments": ["--stdio"]
-    }
-  }
-},
-```
-
-Where `PATH TO BINARY` is a location to a local build, eg. `/Users/user/next-ls/burrito_out/next_ls_darwin_arm64`.
+And, if you want to run a local version of `next-ls` make sure your local build is in your path named `nextls`.
 
 ## Sublime Text
 


### PR DESCRIPTION
I've changed:

- how you turn on `next-ls` in Zed
- how you set it up to use local build (useful for development and debugging)